### PR TITLE
Pass basic auth settings in baseURL to xmlrpc lib

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -7,7 +7,6 @@
 */
 
 const xmlrpc = require('xmlrpc');
-const url = require('url');
 
 class OdooAwait {
 
@@ -31,9 +30,10 @@ class OdooAwait {
     }
 
     const options = opts ? Object.assign(defaults, opts) : defaults;
+    const url = new URL(options.baseUrl);
 
-    this.host = url.parse(options.baseUrl).hostname;
-    this.secure = url.parse(options.baseUrl).protocol === 'https:';
+    this.host = url.hostname;
+    this.secure = url.protocol === 'https:';
     this.port = options.port;
     this.db = options.db;
     this.username = options.username;

--- a/lib/index.js
+++ b/lib/index.js
@@ -32,9 +32,18 @@ class OdooAwait {
     const options = opts ? Object.assign(defaults, opts) : defaults;
     const url = new URL(options.baseUrl);
 
+    const basicAuth =
+      url.username !== ''
+        ? {
+            user: url.username,
+            pass: url.password,
+          }
+        : null;
+
     this.host = url.hostname;
     this.secure = url.protocol === 'https:';
     this.port = options.port;
+    this.basicAuth = basicAuth;
     this.db = options.db;
     this.username = options.username;
     this.password = options.password;
@@ -48,10 +57,16 @@ class OdooAwait {
   connect(){
     let self = this;
     let client;
+    const clientOptions = {
+      host: this.host,
+      port: this.port,
+      path: '/xmlrpc/2/common',
+      basic_auth: this.basicAuth
+    };
     if(this.secure){
-      client = xmlrpc.createSecureClient({host: this.host, port: this.port, path: '/xmlrpc/2/common'});
+      client = xmlrpc.createSecureClient(clientOptions);
     }else{
-      client = xmlrpc.createClient({host: this.host, port: this.port, path: '/xmlrpc/2/common'});
+      client = xmlrpc.createClient(clientOptions);
     }
 
 


### PR DESCRIPTION
I also took the liberty to replace the legacy `url.parse` with the nodejs `URL` class.
This may or may not be a breaking change, since `url.parse` only throws a `TypeError` if the given URL is not a string. The `URL` class throws the error, if the input is not a valid URL.

See https://nodejs.org/api/url.html#url_new_url_input_base
and https://nodejs.org/api/url.html#url_url_parse_urlstring_parsequerystring_slashesdenotehost