### PR TITLE
Additional context option for searchRead

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -248,7 +248,7 @@ class OdooAwait {
    * @param {object} [opts] - options e.g. { offset: 100, limit: 5, order: 'category, birthday desc' }
    * @return {Promise<Array>}
    */
-  async searchRead(model, domain, fields = [],  opts = { offset: 0, limit: 0, order: ''}) {
+  async searchRead(model, domain, fields = [], opts = { offset: 0, limit: 0, order: '', context: {}}) {
 
     let domainArray = [];
     if(domain){
@@ -267,7 +267,7 @@ class OdooAwait {
 
     let params = [];
     params.push([domainArray]);
-    params.push({fields: fields, offset: opts.offset, limit: opts.limit, order: opts.order});
+    params.push({fields: fields, offset: opts.offset, limit: opts.limit, order: opts.order, context: opts.context});
 
     return await this.execute_kw(model, 'search_read', params);
 


### PR DESCRIPTION
There should be an additional context field, where we can pass some extra Odoo params. 

I.e. 
context: { lang: 'en_US'}