### PR TITLE
Add function to create client options

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -64,18 +64,28 @@ class OdooAwait {
   }
 
   /**
+   * Assemble options for xmlrpc client using given path.
+   * @param {string} path The path to use for XMLRPC
+   * @returns options to be used with xmlrpc client
+   */
+  createClientOptions(path){
+    return {
+      host: this.host,
+      port: this.port,
+      basic_auth: this.basicAuth,
+      path
+    };
+  }
+
+  /**
    * Connect to Odoo. Must be called before calling other methods.
    * @return {Promise<number>} - returns user ID if connected
    */
   connect(){
     let self = this;
     let client;
-    const clientOptions = {
-      host: this.host,
-      port: this.port,
-      path: '/xmlrpc/2/common',
-      basic_auth: this.basicAuth
-    };
+    const clientOptions = this.createClientOptions('/xmlrpc/2/common');
+
     if(this.secure){
       client = xmlrpc.createSecureClient(clientOptions);
     }else{
@@ -115,13 +125,9 @@ class OdooAwait {
    */
   execute_kw(model, method, params) {
 
-    const clientOpts = {
-      host: this.host,
-      port: this.port,
-      path: '/xmlrpc/2/object'
-    }
+    const clientOptions = this.createClientOptions('/xmlrpc/2/object');
 
-    let client = this.secure ? xmlrpc.createSecureClient(clientOpts) : xmlrpc.createClient(clientOpts);
+    let client = this.secure ? xmlrpc.createSecureClient(clientOptions) : xmlrpc.createClient(clientOptions);
 
     params.unshift( this.db, this.uid, this.password, model, method);
 


### PR DESCRIPTION
In PR #17 I forgot to add the basic auth info to the client options in `execute_kw`.
The function centralizes the options creation, so this won't be a problem in the future.